### PR TITLE
UIPCIR-1: Fix instance parsing

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -98,7 +98,18 @@ export const parseIdentifiers = (instance, identifierTypesByName) => {
 };
 
 export const parseInstance = (instance, identifierTypesByName) => {
-  instance.identifiers = parseIdentifiers(instance, identifierTypesByName);
+  const identifiers = parseIdentifiers(instance, identifierTypesByName);
+
+  if (identifiers.length) {
+    instance.identifiers = identifiers;
+  }
+
+  if (!instance.contributors.length) {
+    delete instance.contributors;
+  }
+
+  instance.staffSuppress = false;
+  instance.source = 'FOLIO';
 
   return instance;
 };


### PR DESCRIPTION
The instance was not created successfully because couple additional props were missing. This PR is addressing that.