### PR TITLE
Add ability to control plugin visibility from the outside

### DIFF
--- a/src/CreateRecordsPlugin.js
+++ b/src/CreateRecordsPlugin.js
@@ -1,27 +1,71 @@
-import React, { useState, useCallback } from 'react';
+import React, {
+  useState,
+  useCallback,
+  useEffect,
+} from 'react';
+import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
 import { Button } from '@folio/stripes/components';
 
 import CreateRecordsModal from './CreateRecordsModal';
 
-const CreateRecordsPlugin = () => {
+const CreateRecordsPlugin = ({
+  buttonStyle,
+  open,
+  onOpen,
+  onClose,
+  buttonVisible,
+}) => {
   const [isModalOpen, toggleModal] = useState(false);
-  const openModal = useCallback(() => toggleModal(true), []);
-  const closeModal = useCallback(() => toggleModal(false), []);
+
+  const openModal = useCallback(() => {
+    toggleModal(true);
+
+    if (onOpen) {
+      onOpen();
+    }
+  }, [onOpen]);
+
+  const closeModal = useCallback(() => {
+    toggleModal(false);
+
+    if (onClose) {
+      onClose();
+    }
+  }, [onClose]);
+
+  useEffect(() => toggleModal(open), [open]);
 
   return (
     <>
-      <Button
-        data-test-add-inventory-records
-        marginBottom0
-        onClick={openModal}
-      >
-        <FormattedMessage id="ui-plugin-create-inventory-records.fastAddLabel" />
-      </Button>
+      {
+        buttonVisible &&
+        <Button
+          data-test-add-inventory-records
+          buttonStyle={buttonStyle}
+          marginBottom0
+          onClick={openModal}
+        >
+          <FormattedMessage id="ui-plugin-create-inventory-records.fastAddLabel" />
+        </Button>
+      }
       {isModalOpen && <CreateRecordsModal onClose={closeModal} />}
-    </> //
+    </>
   );
+};
+
+CreateRecordsPlugin.defaultProps = {
+  buttonVisible: true,
+  open: false,
+};
+
+CreateRecordsPlugin.propTypes = {
+  buttonStyle: PropTypes.string,
+  buttonVisible: PropTypes.bool,
+  open: PropTypes.bool,
+  onOpen: PropTypes.func,
+  onClose: PropTypes.func,
 };
 
 export default CreateRecordsPlugin;

--- a/test/bigtest/helpers/PluginHarness.js
+++ b/test/bigtest/helpers/PluginHarness.js
@@ -6,6 +6,8 @@ const PluginHarness = (props) => (
     aria-haspopup="true"
     type="create-inventory-records"
     id="clickable-add-inventory-records"
+    onOpen={() => {}}
+    onClose={() => {}}
     {...props}
   >
     <span data-test-no-plugin-available>No plugin available!</span>


### PR DESCRIPTION
Add `open` and `buttonVisible` to the list of plugin props in order to allow for controlling its visibility from the outside.
This should help with the situation described in https://issues.folio.org/browse/UIIN-907

````js
<Pluggable
  buttonVisible={false}
  open={showNewFastAddModal}
  type="create-inventory-records"
  id="clickable-create-inventory-records"
  onClose={this.toggleNewFastAddModal}
/>
````