### PR TITLE
UIPCIR-6 include displayName

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
       },
       {
         "permissionName": "ui-plugin-create-inventory-records.create",
+        "displayName": "Fast add: Create",
         "subPermissions": [
           "module.inventory.enabled",
           "inventory.instances.item.post",


### PR DESCRIPTION
The `displayName` attribute isn't technically required since translation
of `permissionName` values is handled by the regular translation
mechanism, but some scripts still search by `displayName` so it's
helpful when that value is present.

Refs [UIPCIR-6](https://issues.folio.org/browse/UIPCIR-6)