### PR TITLE
UIIN-1368: Update permission for because of renaming of instance-bulk endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-plugin-create-inventory-records
 
+## 2.0.0 (IN PROGRESS)
+* Update permission for because of renaming of instance-bulk endpoint. Refs UIIN-1368.
+
 ## [1.0.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v1.0.0) (2020-10-13)
 
 * Removed permission allowing access to inventory.  Addresses UIPCIR-12.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/plugin-create-inventory-records",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Create inventory records for Stripes",
   "repository": "folio-org/ui-plugin-create-inventory-records",
   "publishConfig": {
@@ -107,7 +107,7 @@
           "inventory-storage.service-points.get",
           "inventory-storage.service-points.collection.get",
           "inventory-storage.hrid-settings.item.get",
-          "inventory-storage.instance-bulk.ids.get"
+          "inventory-storage.record-bulk.ids.get"
         ],
         "visible": true
       }


### PR DESCRIPTION
## Purpose

Update permission for because of the renaming of instance-bulk endpoint in the scope of the [UIIN-1368](https://issues.folio.org/browse/UIIN-1368).