### PR TITLE
UICR-91: Pass created record's data to onClose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.0 (IN PROGRESS)
 * Update permission for because of renaming of instance-bulk endpoint. Refs UIIN-1368.
+* Updated `onClose` prop to receive arg containing instance, holdings, and item record data. Refs UICR-91.
 
 ## [1.0.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v1.0.0) (2020-10-13)
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ type="create-inventory-records">` element. See [the *Plugins*
 section](https://github.com/folio-org/stripes-core/blob/master/doc/dev-guide.md#plugins)
 of the Module Developer's Guide.
 
+## Props
+
+The following props can be passed to the `Pluggable` component. They will be passed through to this plugin.
+
+| prop | type | description |
+|------|------|-------------|
+| `buttonVisible` | boolean | When true, this plugin will render its own trigger that opens the modal |
+| `onClose` | Object: `{ instanceRecord, holdingsRecord, itemRecord }` | Function called upon closing the modal. If the close is the result of a successful record creation, then an object will be passed that contains info about the created records. |
+| `open` | boolean | When true, this plugin will render the record-creation modal. |
+
 ## Additional information
 
 Other [modules](https://dev.folio.org/source-code/#client-side).

--- a/src/CreateRecordsPlugin.js
+++ b/src/CreateRecordsPlugin.js
@@ -28,11 +28,11 @@ const CreateRecordsPlugin = ({
     }
   }, [onOpen]);
 
-  const closeModal = useCallback(() => {
+  const closeModal = useCallback((...args) => {
     toggleModal(false);
 
     if (onClose) {
-      onClose();
+      onClose(...args);
     }
   }, [onClose]);
 

--- a/src/CreateRecordsWrapper.js
+++ b/src/CreateRecordsWrapper.js
@@ -72,13 +72,17 @@ const CreateRecordsWrapper = ({
     try {
       const instanceRecord = await createInstanceRecord.POST(parseInstance(instance, identifierTypesByName));
       const holdingsRecord = await createHoldingsRecord.POST(parseHolding(holding, instanceRecord));
-      await createItemRecord.POST(parseItem(item, holdingsRecord));
+      const itemRecord = await createItemRecord.POST(parseItem(item, holdingsRecord));
 
       callout.sendCallout({
         message: <FormattedMessage id="ui-plugin-create-inventory-records.onSave.success" />,
       });
 
-      onClose();
+      onClose({
+        instanceRecord,
+        holdingsRecord,
+        itemRecord,
+      });
     } catch (error) {
       callout.sendCallout({
         message: <FormattedMessage id="ui-plugin-create-inventory-records.onSave.error" />,


### PR DESCRIPTION
We're gonna want this for [UICR-91](https://issues.folio.org/browse/UICR-91), which adds Fast Add functionality to the Courses app. The goal is to be able to do the following:
- Hit a `Add Fast Add item` button in Courses.
- This plugin's create-record modal comes up. 
- User fills out the required data, hits `Save and Close`.
- Courses _gets the data (the item's `id`, specifically) of the newly-created record_ and uses that to add a new course reserve item.

The italicised bit in the last item is key and what this PR adds since we otherwise would have to do something like search for the newly-created item which seems subelegant. 

Example usage in parent app:
```
      <Pluggable
        buttonVisible={false}
        id="clickable-create-fast-add-inventory-records"
        onClose={({ itemRecord }) => {
          mutator.reserves.POST({ courseListingId, itemId: itemRecord.id });
          setShowNewFastAddModal(false);
        }}
        open={showNewFastAddModal}
        type="create-inventory-records"
      />
```