### PR TITLE
Added IfPermission check and renderTrigger prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Updated `onClose` prop to receive arg containing instance, holdings, and item record data. Refs UICR-91.
 * Wrapped rendering in an `IfPermission` check.
 * Added `renderTrigger` prop to customize trigger rendering within the `IfPermission` check.
+* BREAKING CHANGE - Removed `buttonVisible` prop. `renderTrigger` should be used instead.
 
 ## [1.0.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v1.0.0) (2020-10-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 2.0.0 (IN PROGRESS)
 * Update permission for because of renaming of instance-bulk endpoint. Refs UIIN-1368.
 * Updated `onClose` prop to receive arg containing instance, holdings, and item record data. Refs UICR-91.
+* Wrapped rendering in an `IfPermission` check.
+* Added `renderTrigger` prop to customize trigger rendering within the `IfPermission` check.
 
 ## [1.0.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v1.0.0) (2020-10-13)
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The following props can be passed to the `Pluggable` component. They will be pas
 | `buttonVisible` | boolean | When true, this plugin will render its own trigger that opens the modal |
 | `onClose` | Object: `{ instanceRecord, holdingsRecord, itemRecord }` | Function called upon closing the modal. If the close is the result of a successful record creation, then an object will be passed that contains info about the created records. |
 | `open` | boolean | When true, this plugin will render the record-creation modal. |
+| `renderTrigger` | Function: `({ id, onClick }) => <YourButton />` | A render-function that is passed a props object and returns JSX. Used to customize the rendering of a trigger to open the record-creation modal. |
 
 ## Additional information
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ The following props can be passed to the `Pluggable` component. They will be pas
 
 | prop | type | description |
 |------|------|-------------|
-| `buttonVisible` | boolean | When true, this plugin will render its own trigger that opens the modal |
 | `onClose` | Object: `{ instanceRecord, holdingsRecord, itemRecord }` | Function called upon closing the modal. If the close is the result of a successful record creation, then an object will be passed that contains info about the created records. |
 | `open` | boolean | When true, this plugin will render the record-creation modal. |
 | `renderTrigger` | Function: `({ id, onClick }) => <YourButton />` | A render-function that is passed a props object and returns JSX. Used to customize the rendering of a trigger to open the record-creation modal. |

--- a/src/CreateRecordsPlugin.js
+++ b/src/CreateRecordsPlugin.js
@@ -7,16 +7,18 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 
 import { Button } from '@folio/stripes/components';
+import { IfPermission } from '@folio/stripes/core';
 
 import DataProvider from './providers/DataProvider';
 import CreateRecordsWrapper from './CreateRecordsWrapper';
 
 const CreateRecordsPlugin = ({
   buttonStyle,
+  buttonVisible,
   open,
   onOpen,
   onClose,
-  buttonVisible,
+  renderTrigger,
 }) => {
   const [isModalOpen, toggleModal] = useState(false);
 
@@ -38,25 +40,33 @@ const CreateRecordsPlugin = ({
 
   useEffect(() => toggleModal(open), [open]);
 
+  const triggerProps = {
+    'data-test-add-inventory-records': true,
+    id: 'add-inventory-record-trigger-btn',
+    onClick: openModal,
+  };
+
   return (
-    <>
+    <IfPermission perm="ui-plugin-create-inventory-records.create">
       {
-        !isModalOpen && buttonVisible &&
-        <Button
-          data-test-add-inventory-records
-          buttonStyle={buttonStyle}
-          marginBottom0
-          onClick={openModal}
-        >
-          <FormattedMessage id="ui-plugin-create-inventory-records.fastAddLabel" />
-        </Button>
+        !isModalOpen &&
+          (buttonVisible || renderTrigger) && // if either are true, the plugin is responsible for rendering
+          (renderTrigger ? renderTrigger(triggerProps) : (
+            <Button
+              buttonStyle={buttonStyle}
+              marginBottom0
+              {...triggerProps}
+            >
+              <FormattedMessage id="ui-plugin-create-inventory-records.fastAddLabel" />
+            </Button>
+          ))
       }
       {isModalOpen &&
         <DataProvider>
           <CreateRecordsWrapper onClose={closeModal} />
         </DataProvider>
       }
-    </>
+    </IfPermission>
   );
 };
 
@@ -71,6 +81,7 @@ CreateRecordsPlugin.propTypes = {
   open: PropTypes.bool,
   onOpen: PropTypes.func,
   onClose: PropTypes.func,
+  renderTrigger: PropTypes.func,
 };
 
 export default CreateRecordsPlugin;

--- a/src/CreateRecordsPlugin.js
+++ b/src/CreateRecordsPlugin.js
@@ -14,7 +14,6 @@ import CreateRecordsWrapper from './CreateRecordsWrapper';
 
 const CreateRecordsPlugin = ({
   buttonStyle,
-  buttonVisible,
   open,
   onOpen,
   onClose,
@@ -50,7 +49,6 @@ const CreateRecordsPlugin = ({
     <IfPermission perm="ui-plugin-create-inventory-records.create">
       {
         !isModalOpen &&
-          (buttonVisible || renderTrigger) && // if either are true, the plugin is responsible for rendering
           (renderTrigger ? renderTrigger(triggerProps) : (
             <Button
               buttonStyle={buttonStyle}
@@ -71,13 +69,11 @@ const CreateRecordsPlugin = ({
 };
 
 CreateRecordsPlugin.defaultProps = {
-  buttonVisible: true,
   open: false,
 };
 
 CreateRecordsPlugin.propTypes = {
   buttonStyle: PropTypes.string,
-  buttonVisible: PropTypes.bool,
   open: PropTypes.bool,
   onOpen: PropTypes.func,
   onClose: PropTypes.func,

--- a/test/bigtest/interactors/createRecordsPlugin.js
+++ b/test/bigtest/interactors/createRecordsPlugin.js
@@ -6,6 +6,8 @@ import {
   fillable,
   is,
   isPresent,
+  text,
+  attribute,
 } from '@bigtest/interactor';
 
 import CalloutInteractor from '@folio/stripes-components/lib/Callout/tests/interactor';
@@ -63,6 +65,8 @@ import CalloutInteractor from '@folio/stripes-components/lib/Callout/tests/inter
   button = scoped('[data-test-add-inventory-records]', {
     click: clickable(),
     isFocused: is(':focus'),
+    label: text(),
+    id: attribute('id'),
   });
 
   form = new FormInteractor('[data-test-create-records-form]');

--- a/test/bigtest/tests/render-trigger-test.js
+++ b/test/bigtest/tests/render-trigger-test.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { beforeEach, describe, it } from '@bigtest/mocha';
+import { expect } from 'chai';
+
+import { Button } from '@folio/stripes/components';
+import { Pluggable } from '@folio/stripes/core';
+import setupStripesCore from '@folio/stripes-core/test/bigtest/helpers/setup-application';
+
+import mirageOptions from '../network';
+
+import CreateRecordsPluginInteractor from '../interactors/createRecordsPlugin';
+
+const plugin = new CreateRecordsPluginInteractor();
+
+describe('renderTrigger', () => {
+  setupStripesCore({
+    mirageOptions: {
+      serverType: 'miragejs',
+      ...mirageOptions
+    },
+    scenarios: ['default'],
+    stripesConfig: { hasAllPerms: true },
+
+    // setup a dummy app for the plugin that renders the plugin
+    modules: [{
+      type: 'app',
+      name: '@folio/ui-dummy',
+      displayName: 'dummy.title',
+      route: '/dummy',
+      module: () => (
+        <Pluggable
+          aria-haspopup="true"
+          type="create-inventory-records"
+          id="clickable-add-inventory-records"
+          renderTrigger={({ onClick, ...rest }) => (
+            <Button
+              {...rest} // necessary for data-test attrs
+              id="render-trigger-btn"
+              onClick={onClick}
+            >
+              Custom Button
+            </Button>
+          )}
+        />
+      ),
+    }],
+
+    translations: {
+      'dummy.title': 'Dummy App for renderTrigger'
+    },
+  });
+
+  beforeEach(function () {
+    this.visit('/dummy');
+  });
+
+  it('renders button', () => {
+    expect(plugin.button.isPresent).to.be.true;
+  });
+
+  it('renders button with custom text', () => {
+    expect(plugin.button.label).to.equal('Custom Button');
+  });
+
+  it('renders button with custom id', () => {
+    expect(plugin.button.id).to.equal('render-trigger-btn');
+  });
+
+  describe('click trigger button', () => {
+    beforeEach(async () => {
+      await plugin.button.click();
+      await plugin.whenLoaded();
+    });
+
+    it('opens the modal', () => {
+      expect(plugin.form.isPresent).to.be.true;
+    });
+
+    describe('close modal', () => {
+      beforeEach(async () => {
+        await plugin.form.clickCancel();
+      });
+
+      it('closes the modal', () => {
+        expect(plugin.form.isPresent).to.be.false;
+      });
+    });
+  });
+});


### PR DESCRIPTION
This was borne out of [this discussion on Slack in #stripes](https://folio-project.slack.com/archives/C210UCHQ9/p1608132025330900). 

Basically, an app using this plugin doesn't want to render the trigger/button if the user doesn't have the correct permissions. But to accomplish that, they need to use `IfPermission` along with a permission such as `ui-plugin-create-inventory-records.create`. This means that the app has now implemented a dependency on a specific _implementation_ of a plugin, rather than just a dependency on a _type_ of plugin.

Alternatively, they could construct the entire list of atomic permissions themselves, but that's awful for a variety of reasons including maintenance and code sanity.

By moving the `IfPermission` into the plugin, the plugin ensures it only renders things when the user is allowed to use them. Now however, we need to give the app some way of controlling the rendering of the trigger. We do this via the `renderTrigger` pattern used in ERM and Acquisitions plugin modules.