### PR TITLE
UIPCIR-20 also support circulation 10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-plugin-create-inventory-records
 
+## 2.1.0 (IN PROGRESS)
+
+* Also support `circulation` `10.0`. Refs UIPCIR-20.
+
 ## [2.0.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v2.0.0) (2021-03-11)
 * Update permission for because of renaming of instance-bulk endpoint. Refs UIIN-1368.
 * Updated `onClose` prop to receive arg containing instance, holdings, and item record data. Refs UICR-91.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/plugin-create-inventory-records",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Create inventory records for Stripes",
   "repository": "folio-org/ui-plugin-create-inventory-records",
   "publishConfig": {
@@ -47,7 +47,7 @@
       "holdings-note-types": "1.0",
       "users": "15.0",
       "location-units": "2.0",
-      "circulation": "9.0"
+      "circulation": "9.0 10.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
The only breaking change in `circulation` `10.0` was the removal of the
`override-check-out-by-barcode` which is not used here, hence continuing
to support `9.0`.

Refs [UIPCIR-20(https://issues.folio.org/browse/UIPCIR-20)