### PR TITLE
UIPCIR-21: Update circulation interface dependency to support v11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.1.0 (IN PROGRESS)
 
 * Also support `circulation` `10.0`. Refs UIPCIR-20.
+* Also support `circulation` `11.0`. Refs UIPCIR-21.
 
 ## [2.0.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v2.0.0) (2021-03-11)
 * Update permission for because of renaming of instance-bulk endpoint. Refs UIIN-1368.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
       "holdings-note-types": "1.0",
       "users": "15.0",
       "location-units": "2.0",
-      "circulation": "9.0 10.0"
+      "circulation": "9.0 10.0 11.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
## Purpose
There is a breaking change in mod-circulation (https://github.com/folio-org/mod-circulation/pull/854), circulation interface version will be updated to 11.0.  Other modules should update their dependencies to support this change.

**Do not merge. We have several associated pull request and we need merge them at the same time.**

**API changes**
circulation/override-renewal-by-barcode - will be removed
circulation/renew-by-barcode - request and response will be changed
Current changes will be effect ui-users module

## Refs
https://issues.folio.org/browse/UIPCIR-21