### PR TITLE
UIPCIR-32: Update mocha version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-plugin-create-inventory-records
 
+## IN PROGRESS
+* Update mocha version. Refs UIPCIR-32.
+
 ## [3.0.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v3.0.0) (2021-10-05)
 [Full Changelog](https://github.com/folio-org/ui-plugin-create-inventory-records/compare/v2.1.0...v3.0.0)
 

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "faker": "^4.1.0",
     "inflected": "^2.0.4",
     "miragejs": "^0.1.40",
+    "mocha": "^9.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-intl": "^5.8.0",


### PR DESCRIPTION
## Purpose
Bigtests fails after this [pull request](https://github.com/folio-org/stripes-webpack/pull/43)

## Approach
Add required mocha version as dependency

## Refs
https://issues.folio.org/browse/UIPCIR-32