### PR TITLE
UIPCIR-42: instance-storage 9.0, holdings-storage 6.0, item-storage 10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.2.0] IN PROGRESS
 
 * Debounce barcode validation. Fixes UIPCIR-40.
+* Also support `instance-storage` `9.0`, `holdings-storage` `6.0`, `item-storage` `10.0`. Refs UIPCIR-42.
 
 ## [3.1.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v3.1.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-plugin-create-inventory-records/compare/v3.0.0...v3.1.0)

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "okapiInterfaces": {
       "inventory": "10.0 11.0",
       "source-storage-records": "2.0 3.0",
-      "instance-storage": "7.0 8.0",
-      "holdings-storage": "3.0 4.0 5.0",
-      "item-storage": "8.0 9.0",
+      "instance-storage": "7.0 8.0 9.0",
+      "holdings-storage": "3.0 4.0 5.0 6.0",
+      "item-storage": "8.0 9.0 10.0",
       "loan-types": "2.0",
       "material-types": "2.0",
       "item-note-types": "1.0",


### PR DESCRIPTION
mod-inventory-storage has new major interface versions:

instance-storage 9.0
holdings-storage 6.0
item-storage 10.0

ui-plugin-create-inventory-records is not affected because the incompatible change is in the DELETE all APIs only.

Only the okapiInterfaces need to be bumped in package.json.