### PR TITLE
UIPCIR-44: Support inventory 12.0 in okapiInterfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## [3.2.0] IN PROGRESS
 
 * Debounce barcode validation. Fixes UIPCIR-40.
-* Also support `instance-storage` `9.0`, `holdings-storage` `6.0`, `item-storage` `10.0`. Refs UIPCIR-42.
+* Also support `instance-storage` `9.0`. Refs UIPCIR-42.
+* Also support `holdings-storage` `6.0`. Refs UIPCIR-42.
+* Also support `item-storage` `10.0`. Refs UIPCIR-42.
+* Also support `inventory` `12.0`. Refs UIPCIR-44.
 
 ## [3.1.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v3.1.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-plugin-create-inventory-records/compare/v3.0.0...v3.1.0)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "pluginType": "create-inventory-records",
     "displayName": "ui-plugin-create-inventory-records.meta.title",
     "okapiInterfaces": {
-      "inventory": "10.0 11.0",
+      "inventory": "10.0 11.0 12.0",
       "source-storage-records": "2.0 3.0",
       "instance-storage": "7.0 8.0 9.0",
       "holdings-storage": "3.0 4.0 5.0 6.0",


### PR DESCRIPTION
Add version `12.0` to the list of supported `inventory` interface versions.

`DELETE /inventory/instances` and `DELETE /inventory/items` have been deleting all records.

MODINV-731 changed them to delete records by CQL, this requires a major interface version bump.

ui-plugin-create-inventory-records doesn't use these two `DELETE` APIs therefore no code change is needed.