### PR TITLE
UIPCIR-41: Bump user interface to v16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Also support `holdings-storage` `6.0`. Refs UIPCIR-42.
 * Also support `item-storage` `10.0`. Refs UIPCIR-42.
 * Also support `inventory` `12.0`. Refs UIPCIR-44.
+* Bump `users` interface to version `16.0`. Refs UIPCIR-41.
 
 ## [3.1.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v3.1.0) (2022-03-03)
 [Full Changelog](https://github.com/folio-org/ui-plugin-create-inventory-records/compare/v3.0.0...v3.1.0)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
       "electronic-access-relationships": "1.0",
       "ill-policies": "1.0",
       "holdings-note-types": "1.0",
-      "users": "15.0",
+      "users": "16.0",
       "location-units": "2.0",
       "circulation": "9.0 10.0 11.0 12.0 13.0"
     },


### PR DESCRIPTION
https://issues.folio.org/browse/UIPCIR-41

The "addresstypeid" field is now "required" as per https://issues.folio.org/browse/MODUSERS-212