### PR TITLE
UIPCIR-47: Set correct `sourceId` on holdings records. Fixes UIPCIR-47.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 3.3.0 IN PROGRESS
 
+* Set correct `sourceId` on holdings records. Fixes UIPCIR-47.
+
 ## [3.2.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v3.2.0) (2022-10-24)
 [Full Changelog](https://github.com/folio-org/ui-plugin-create-inventory-records/compare/v3.1.0...v3.2.0)
 

--- a/src/CreateRecordsWrapper.js
+++ b/src/CreateRecordsWrapper.js
@@ -48,6 +48,7 @@ const CreateRecordsWrapper = ({
 }) => {
   const {
     identifierTypesByName,
+    holdingsSourcesByName,
     settings,
   } = useData();
   const callout = useCallout();
@@ -71,7 +72,7 @@ const CreateRecordsWrapper = ({
 
     try {
       const instanceRecord = await createInstanceRecord.POST(parseInstance(instance, identifierTypesByName));
-      const holdingsRecord = await createHoldingsRecord.POST(parseHolding(holding, instanceRecord));
+      const holdingsRecord = await createHoldingsRecord.POST(parseHolding(holding, instanceRecord, holdingsSourcesByName));
       const itemRecord = await createItemRecord.POST(parseItem(item, holdingsRecord));
 
       callout.sendCallout({
@@ -96,6 +97,7 @@ const CreateRecordsWrapper = ({
     createHoldingsRecord,
     createItemRecord,
     identifierTypesByName,
+    holdingsSourcesByName,
   ]);
 
   if (isLoading) return null;

--- a/src/providers/DataProvider.js
+++ b/src/providers/DataProvider.js
@@ -47,6 +47,7 @@ const DataProvider = ({
     }
     loadedData.settings = config;
     loadedData.identifierTypesByName = keyBy(loadedData.identifierTypes, 'name');
+    loadedData.holdingsSourcesByName = keyBy(loadedData.holdingsSources, 'name');
 
     return loadedData;
   }, [resources, manifest]);
@@ -117,6 +118,15 @@ DataProvider.manifest = Object.freeze({
     records: 'electronicAccessRelationships',
     path: 'electronic-access-relationships?limit=1000&query=cql.allRecords=1 sortby name',
   },
+  holdingsSources: {
+    type: 'okapi',
+    path: 'holdings-sources',
+    params: {
+      query: 'cql.allRecords=1 sortby name',
+      limit: '1000',
+    },
+    records: 'holdingsRecordsSources',
+  }
 });
 
 export default stripesConnect(DataProvider);

--- a/src/util.js
+++ b/src/util.js
@@ -178,8 +178,9 @@ export const parseInstance = (instance, identifierTypesByName) => {
   return instance;
 };
 
-export const parseHolding = (holding, instance) => {
+export const parseHolding = (holding, instance, holdingsSourcesByName) => {
   holding.instanceId = instance.id;
+  holding.sourceId = holdingsSourcesByName.FOLIO.id;
 
   return holding;
 };

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -63,6 +63,20 @@ export default function config() {
     totalRecords: 1,
   });
 
+
+  this.get('/holdings-sources', {
+    holdingsRecordsSources: [{
+      id: 'f32d531e-df79-46b3-8932-cdd35f7a2264',
+      name: 'FOLIO',
+      source: 'folio'
+    }, {
+      id: '036ee84a-6afd-4c3c-9ad3-4a12ab875f59',
+      name: 'MARC',
+      source: 'folio'
+    }],
+    totalRecords: 2
+  });
+
   this.get('/locations', {
     locations: [
       {


### PR DESCRIPTION
UIPCIR-47: Set correct `sourceId` on holdings records. Fixes UIPCIR-47.

https://issues.folio.org/browse/UIPCIR-47