### PR TITLE
UIPCIR-52:Fast Add an Instance record - UX consistency: Use Save & close button label stripes-component translation key 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-plugin-create-inventory-records
 
 ## 3.4.0 IN PROGRESS
+* To support UX consistency, the translation key from the stripes components for the save and close button is now used. Fixes UIPCIR-52.
 
 ## [3.3.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v3.3.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-plugin-create-inventory-records/compare/v3.2.0...v3.3.0)

--- a/src/CreateRecordsForm.js
+++ b/src/CreateRecordsForm.js
@@ -103,7 +103,7 @@ const CreateRecordsForm = ({
                 disabled={pristine || submitting}
                 onClick={handleSubmit}
               >
-                <FormattedMessage id="ui-plugin-create-inventory-records.saveAndClose" />
+                <FormattedMessage id="stripes-components.saveAndClose" />
               </Button>
             }
           />

--- a/translations/ui-plugin-create-inventory-records/en.json
+++ b/translations/ui-plugin-create-inventory-records/en.json
@@ -15,7 +15,6 @@
   "selectInstanceStatus": "Select instance status",
   "resourceType": "Resource type",
   "cancel": "Cancel",
-  "saveAndClose": "Save and close",
   "onSave.success": "Inventory records have been created successfully",
   "onSave.error": "Saving inventory records failed",
   "addContributor": "Add contributor",


### PR DESCRIPTION
## Issues
[UIPCIR-52](https://issues.folio.org/browse/UIPCIR-52)

The original work done in: https://github.com/folio-org/ui-plugin-create-inventory-records/pull/136