### PR TITLE
UIPCIR-65: Cover `CreateRecordsPlugin` component with unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Jest/RTL: Cover `useOptions` hook with unit tests. Refs UIPCIR-68.
 * Jest/RTL: Cover `CreateRecordsWrapper` component with unit tests. Refs UIPCIR-64.
 * Jest/RTL: Cover `CreateRecordsForm` component with unit tests. Refs UIPCIR-66.
+* Jest/RTL: Cover `CreateRecordsPlugin` component with unit tests. Refs UIPCIR-65.
 
 ## [4.0.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v4.0.0) (2023-10-12)
 [Full Changelog](https://github.com/folio-org/ui-plugin-create-inventory-records/compare/v3.3.0...v4.0.0)

--- a/src/CreateRecordsPlugin.test.js
+++ b/src/CreateRecordsPlugin.test.js
@@ -1,0 +1,62 @@
+import { fireEvent } from '@folio/jest-config-stripes/testing-library/react';
+
+import {
+  renderWithIntl,
+  translationsProperties,
+} from '../test/jest/helpers';
+
+import CreateRecordsWrapper from './CreateRecordsWrapper';
+import CreateRecordsPlugin from './CreateRecordsPlugin';
+
+jest.mock('./providers/DataProvider', () => jest.fn(({ children }) => <div id='data-provider'>{children}</div>));
+jest.mock('./CreateRecordsWrapper', () => jest.fn().mockReturnValue('CreateRecordsWrapper'));
+
+const renderCustomButton = () => <button>Custom button</button>;
+const defaultProps = {
+  onOpen: jest.fn(),
+  onClose: jest.fn(),
+};
+
+const renderCreateRecordsPlugin = props => {
+  const component = <CreateRecordsPlugin {...defaultProps} {...props} />;
+
+  return renderWithIntl(component, translationsProperties);
+};
+
+describe('CreateRecordsPlugin component', () => {
+  it('should render the button to add the record', () => {
+    const { getByText } = renderCreateRecordsPlugin();
+
+    expect(getByText('New fast add record')).toBeInTheDocument();
+  });
+
+  describe('when click the button', () => {
+    it('should render the modal', () => {
+      const { getByText } = renderCreateRecordsPlugin();
+
+      fireEvent.click(getByText('New fast add record'));
+  
+      expect(getByText('CreateRecordsWrapper')).toBeInTheDocument();
+    });
+  });
+
+  describe('when close the modal', () => {
+    it('should call the function to close the modal', () => {
+      const { getByText } = renderCreateRecordsPlugin();
+
+      fireEvent.click(getByText('New fast add record'));
+
+      CreateRecordsWrapper.mock.calls[0][0].onClose();
+  
+      expect(defaultProps.onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('when renderTrigger prop is provided', () => {
+    it('should render the custom button', () => {
+      const { getByText } = renderCreateRecordsPlugin({ renderTrigger: renderCustomButton });
+  
+      expect(getByText('Custom button')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Links
[UIPCIR-65](https://folio-org.atlassian.net/browse/UIPCIR-65)

## Screenshots
![image](https://github.com/folio-org/ui-plugin-create-inventory-records/assets/85172747/8e8ea47e-5976-4d0e-916f-602fe15ea106)
