### PR TITLE
UIPCIR-69: Jest/RTL: Cover useIsLoading hook with unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-plugin-create-inventory-records
 
+## [4.2.0] (IN PROGRESS)
+
+* Jest/RTL: Cover useIsLoading hook with unit tests. Refs UIPCIR-69.
+
 ## [4.1.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v4.1.0) (2024-03-21)
 [Full Changelog](https://github.com/folio-org/ui-plugin-create-inventory-records/compare/v4.0.0...v4.1.0)
 

--- a/src/hooks/tests/useIsLoading.test.js
+++ b/src/hooks/tests/useIsLoading.test.js
@@ -1,0 +1,16 @@
+import { renderHook } from '@folio/jest-config-stripes/testing-library/react';
+
+import { DataContext  } from '../../contexts';
+import useIsLoading from '../useIsLoading';
+
+const wrapper = ({ children }) => (
+  <DataContext.Provider value={{ isLoading: () => false }}>{children}</DataContext.Provider>
+);
+
+describe('useIsLoading hook', () => {
+  it('should return value of isLoading method from the context', () => {
+    const { result } = renderHook(() => useIsLoading(), { wrapper });
+
+    expect(result.current).toEqual(false);
+  });
+});


### PR DESCRIPTION
Cover useIsLoading hook with unit tests using Jest + RTL. Make sure that test coverage is not lower than 80%.

https://folio-org.atlassian.net/browse/UIPCIR-69