### PR TITLE
UIPCIR-74: Jest/RTL: Cover `HoldingAccordion` component with unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## [4.2.0] (IN PROGRESS)
 
-* Jest/RTL: Cover useIsLoading hook with unit tests. Refs UIPCIR-69.
+* Jest/RTL: Cover `useIsLoading` hook with unit tests. Refs UIPCIR-69.
+* Jest/RTL: Cover `HoldingAccordion` component with unit tests. Refs UIPCIR-74.
 
 ## [4.1.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v4.1.0) (2024-03-21)
 [Full Changelog](https://github.com/folio-org/ui-plugin-create-inventory-records/compare/v4.0.0...v4.1.0)

--- a/src/components/HoldingAccordion/HoldingAccordion.test.js
+++ b/src/components/HoldingAccordion/HoldingAccordion.test.js
@@ -1,0 +1,100 @@
+import { screen } from '@folio/jest-config-stripes/testing-library/react';
+
+import {
+  renderWithIntl,
+  renderWithRouter,
+  translationsProperties,
+  renderWithFinalForm,
+} from '../../../test/jest/helpers';
+
+import {
+  LocationSelection,
+  LocationLookup,
+} from '@folio/stripes/smart-components';
+
+import HoldingAccordion from './HoldingAccordion';
+
+jest.mock('@folio/stripes/smart-components', () => ({
+  ...jest.requireActual('@folio/stripes/smart-components'),
+  LocationSelection: jest.fn(() => <span>LocationSelection</span>),
+  LocationLookup: jest.fn(() => <span>LocationLookup</span>),
+}));
+jest.mock('../../hooks', () => ({
+  ...jest.requireActual('../../hooks'),
+  useData: jest.fn(() => ({ callNumberTypes: [] })),
+  useOptions: jest.fn(),
+}));
+
+const onChangeMock = jest.fn();
+
+const renderHoldingAccordion = () => renderWithIntl(
+  renderWithRouter(renderWithFinalForm(<HoldingAccordion change={onChangeMock} />)),
+  translationsProperties,
+);
+
+describe('HoldingAccordion', () => {
+  afterEach(() => {
+    onChangeMock.mockClear();
+    LocationLookup.mockClear();
+    LocationSelection.mockClear();
+  });
+
+  it('should render holding accordion', () => {
+    renderHoldingAccordion();
+
+    expect(screen.getByRole('button', { name: /holdings/i })).toBeInTheDocument();
+  });
+
+  it('should render correct fields', () => {
+    renderHoldingAccordion();
+
+    expect(screen.getByRole('combobox', { name: 'Call number type' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Call number prefix' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Call number' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Call number suffix' })).toBeInTheDocument();
+  });
+
+  describe('when select permanent location', () => {
+    describe('and location is without id', () => {
+      it('should set the location as an empty string', () => {
+        renderHoldingAccordion();
+
+        LocationSelection.mock.calls[0][0].onSelect();
+
+        expect(onChangeMock).toHaveBeenCalledWith('holding.permanentLocationId', '');
+      });
+    });
+  
+    describe('and location is with id', () => {
+      it('should set the location', () => {
+        renderHoldingAccordion();
+
+        LocationLookup.mock.calls[0][0].onLocationSelected({ id: 'testId' });
+
+        expect(onChangeMock).toHaveBeenCalledWith('holding.permanentLocationId', 'testId');
+      });
+    });
+  });
+
+  describe('when select temporary location', () => {
+    describe('and location is without id', () => {
+      it('should set the location as an empty string', () => {
+        renderHoldingAccordion();
+
+        LocationSelection.mock.calls[1][0].onSelect();
+
+        expect(onChangeMock).toHaveBeenCalledWith('holding.temporaryLocationId', '');
+      });
+    });
+  
+    describe('and location is with id', () => {
+      it('should set the location', () => {
+        renderHoldingAccordion();
+
+        LocationLookup.mock.calls[1][0].onLocationSelected({ id: 'testId' });
+
+        expect(onChangeMock).toHaveBeenCalledWith('holding.temporaryLocationId', 'testId');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Links
[UIPCIR-74](https://folio-org.atlassian.net/browse/UIPCIR-74)
## Screenshots
![image](https://github.com/folio-org/ui-plugin-create-inventory-records/assets/85172747/57f9e7ad-f730-4bb6-b2ef-56a728e54fd2)

