### PR TITLE
UIPCIR-67: Cover `DataProvider` component with unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Jest/RTL: Cover `useCallout` hook with unit tests. Refs UIPCIR-71.
 * "holdings-storage" API version update. Refs UIPCIR-82.
 * Jest/RTL: Cover `useData` hook with unit tests. Refs UIPCIR-70.
+* Jest/RTL: Cover `DataProvider` component with unit tests. Refs UIPCIR-67.
 
 ## [4.1.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v4.1.0) (2024-03-21)
 [Full Changelog](https://github.com/folio-org/ui-plugin-create-inventory-records/compare/v4.0.0...v4.1.0)

--- a/src/providers/DataProvider.test.js
+++ b/src/providers/DataProvider.test.js
@@ -1,0 +1,80 @@
+import React, { useContext } from 'react';
+import { render } from '@folio/jest-config-stripes/testing-library/react';
+
+import '../../test/jest/__mock__';
+
+import { DataContext } from '../contexts';
+import DataProvider from './DataProvider';
+
+const mockResources = {
+  contributorNameTypes: { hasLoaded: true, records: null },
+  instanceTypes: { hasLoaded: true, records: null },
+  instanceStatuses: { hasLoaded: true, records: [{ code: 'test', id: 'testId' }] },
+  configs: { hasLoaded: true, records: [{ value: '{"instanceStatusCode":"test","defaultDiscoverySuppress":"true"}' }] },
+  identifierTypes: { hasLoaded: true, records: [{ name: 'test' }] },
+  callNumberTypes: { hasLoaded: true, records: null },
+  materialTypes: { hasLoaded: true, records: [] },
+  loanTypes: { hasLoaded: true, records: [] },
+  electronicAccessRelationships: { hasLoaded: true, records: [] },
+  holdingsSources: { hasLoaded: true, records: [{ name: 'test' }] },
+};
+
+let contextValue;
+
+const TestComponent = () => {
+  contextValue = useContext(DataContext);
+
+  return <span>TestComponent</span>;
+};
+
+const renderDataProvider = resources =>
+  render(
+    <DataProvider resources={resources}>
+      <TestComponent />
+    </DataProvider>
+  );
+
+describe('DataProvider component', () => {
+  it('should provide correct data and isLoading function when resources are loaded', () => {
+    renderDataProvider(mockResources);
+
+    expect(contextValue.isLoading()).toBeFalsy();
+    expect(contextValue.data).toMatchObject({
+      contributorNameTypes: [],
+      instanceTypes: [],
+      instanceStatuses: [{ code: 'test', id: 'testId' }],
+      configs: [{ value: '{"instanceStatusCode":"test","defaultDiscoverySuppress":"true"}' }],
+      identifierTypes: [{ name: 'test' }],
+      callNumberTypes: [],
+      materialTypes: [],
+      loanTypes: [],
+      electronicAccessRelationships: [],
+      holdingsSources: [{ name: 'test' }],
+      settings: { discoverySuppress: true, statusId: 'testId' },
+      identifierTypesByName: { test: { name: 'test' } },
+      holdingsSourcesByName: { test: { name: 'test' } },
+    });
+  });
+
+  it('should set isLoading to true when some resources are not loaded', () => {
+    const notLoadedResources = {
+      ...mockResources,
+      instanceTypes: { hasLoaded: false, records: [] },
+    };
+
+    renderDataProvider(notLoadedResources);
+
+    expect(contextValue.isLoading()).toBeTruthy();
+  });
+
+  it('should provide default empty settings when configs value is invalid', () => {
+    const invalidConfigResources = {
+      ...mockResources,
+      configs: { hasLoaded: true, records: [{ value: 'invalid json' }] },
+    };
+
+    renderDataProvider(invalidConfigResources);
+
+    expect(contextValue.data.settings).toMatchObject({});
+  });
+});


### PR DESCRIPTION
## Links
[UIPCIR-67](https://folio-org.atlassian.net/browse/UIPCIR-67)

## Screenshots
![image](https://github.com/user-attachments/assets/d81a4223-48b3-4388-9d4e-8818ebf3c962)
