### PR TITLE
UIPCIR-86: Support `instance-storage v11.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * "holdings-storage" API version update. Refs UIPCIR-82.
 * Jest/RTL: Cover `useData` hook with unit tests. Refs UIPCIR-70.
 * Jest/RTL: Cover `DataProvider` component with unit tests. Refs UIPCIR-67.
+* *BREAKING* Upgrade `instance-storage` to `11.0`. Refs UIPCIR-86.
 
 ## [4.1.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v4.1.0) (2024-03-21)
 [Full Changelog](https://github.com/folio-org/ui-plugin-create-inventory-records/compare/v4.0.0...v4.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Jest/RTL: Cover `useData` hook with unit tests. Refs UIPCIR-70.
 * Jest/RTL: Cover `DataProvider` component with unit tests. Refs UIPCIR-67.
 * Update `actions/upload-artifact@v2` to `actions/upload-artifact@v4`. Refs UIPCIR-87.
-* *BREAKING* Upgrade `instance-storage` to `11.0`. Refs UIPCIR-86.
+* Also support `instance-storage` `11.0`. Refs UIPCIR-86.
 
 ## [4.1.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v4.1.0) (2024-03-21)
 [Full Changelog](https://github.com/folio-org/ui-plugin-create-inventory-records/compare/v4.0.0...v4.1.0)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "okapiInterfaces": {
       "inventory": "10.0 11.0 12.0 13.0",
       "source-storage-records": "2.0 3.0",
-      "instance-storage": "7.0 8.0 9.0 10.0",
+      "instance-storage": "7.0 8.0 9.0 10.0 11.0",
       "holdings-storage": "3.0 4.0 5.0 6.0 7.0",
       "item-storage": "8.0 9.0 10.0",
       "loan-types": "2.0",


### PR DESCRIPTION
* Update dependency `instance-storage` to `v11.0`

## Links
[UIPCIR-86](https://folio-org.atlassian.net/browse/UIPCIR-86)