### PR TITLE
UIPCIR-83: Support `holdings-storage` `8.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Also support `inventory` `v14.0`. Refs UIPCIR-85.
 * Also support `instance-storage` `11.0`. Refs UIPCIR-86.
 * Remove bigtest from github workflows. Refs UIPCIR-91.
+* Support `holdings-storage` `8.0`. Refs UIPCIR-83.
 
 ## [4.1.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v4.1.0) (2024-03-21)
 [Full Changelog](https://github.com/folio-org/ui-plugin-create-inventory-records/compare/v4.0.0...v4.1.0)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "inventory": "10.0 11.0 12.0 13.0 14.0",
       "source-storage-records": "2.0 3.0",
       "instance-storage": "7.0 8.0 9.0 10.0 11.0",
-      "holdings-storage": "3.0 4.0 5.0 6.0 7.0",
+      "holdings-storage": "3.0 4.0 5.0 6.0 7.0 8.0",
       "item-storage": "8.0 9.0 10.0",
       "loan-types": "2.0",
       "material-types": "2.0",


### PR DESCRIPTION
[UIPCIR-83](https://folio-org.atlassian.net/browse/UIPCIR-83)
Upgrade the API version in the package.json:

-holdings-storage 8.0