### PR TITLE
UIPCIR-76: Cover ContributorFields component with unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-plugin-create-inventory-records
 
+## 5.1.0 (In progress)
+
+* Jest/RTL: Cover `ContributorFields` component with unit tests. Refs UIPCIR-76.
+
 ## [5.0.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v5.0.0) (2024-10-30)
 [Full Changelog](https://github.com/folio-org/ui-plugin-create-inventory-records/compare/v4.1.0...v5.0.0)
 

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@folio/stripes-cli": "^3.2.0",
     "@folio/stripes-components": "^12.2.0",
     "@folio/stripes-core": "^10.2.0",
+    "@folio/stripes-testing": "^4.7.0",
     "@formatjs/cli": "^6.1.3",
     "core-js": "^3.6.4",
     "react": "^18.2.0",

--- a/src/components/ContributorFields/ContributorFields.test.js
+++ b/src/components/ContributorFields/ContributorFields.test.js
@@ -1,0 +1,46 @@
+import {
+  fireEvent,
+  screen,
+} from '@folio/jest-config-stripes/testing-library/react';
+
+import {
+  renderWithIntl,
+  renderWithRouter,
+  translationsProperties,
+  renderWithFinalForm,
+} from '../../../test/jest/helpers';
+
+import ContributorFields from './ContributorFields';
+
+jest.mock('../../hooks', () => ({
+  ...jest.requireActual('../../hooks'),
+  useData: jest.fn(() => ({ contributorNameTypes: [] })),
+  useOptions: jest.fn(),
+}));
+
+const renderContributorFields = () => {
+  return renderWithIntl(
+    renderWithRouter(renderWithFinalForm(<ContributorFields />)),
+    translationsProperties,
+  );
+};
+
+describe('ContributorFields component', () => {
+  it('should render "Add contributor" button', () => {
+    renderContributorFields();
+
+    expect(screen.getByRole('button', { name: /add contributor/i })).toBeInTheDocument();
+  });
+
+  describe('when click "Add contributor" button', () => {
+    it('should render correct fields', () => {
+      renderContributorFields();
+
+      fireEvent.click(screen.getByRole('button', { name: /add contributor/i }));
+
+      expect(screen.getByRole('textbox', { name: /name/i })).toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: /name type/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /primary/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/ContributorFields/ContributorFields.test.js
+++ b/src/components/ContributorFields/ContributorFields.test.js
@@ -2,6 +2,7 @@ import {
   fireEvent,
   screen,
 } from '@folio/jest-config-stripes/testing-library/react';
+import { runAxeTest } from '@folio/stripes-testing';
 
 import {
   renderWithIntl,
@@ -26,6 +27,12 @@ const renderContributorFields = () => {
 };
 
 describe('ContributorFields component', () => {
+  it('should be rendered with no axe errors', async () => {
+    const { container } = renderContributorFields();
+
+    await runAxeTest({ rootNode: container });
+  });
+
   it('should render "Add contributor" button', () => {
     renderContributorFields();
 
@@ -33,6 +40,14 @@ describe('ContributorFields component', () => {
   });
 
   describe('when click "Add contributor" button', () => {
+    it('should render fields with no axe errors', async () => {
+      const { container } = renderContributorFields();
+
+      fireEvent.click(screen.getByRole('button', { name: /add contributor/i }));
+  
+      await runAxeTest({ rootNode: container });
+    });
+
     it('should render correct fields', () => {
       renderContributorFields();
 


### PR DESCRIPTION
## Links
[UIPCIR-76](https://folio-org.atlassian.net/browse/UIPCIR-76)

## Screenshots
![image](https://github.com/user-attachments/assets/ca8c6907-9cc0-40c5-abd6-95d0a73d6c42)
