### PR TITLE
UIPCIR-94: Migrate stripes dependencies to their Sunflower versions and `react-intl` to v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for ui-plugin-create-inventory-records
 
+## [6.0.0] (IN PROGRESS)
+
+* *BREAKING* Migrate stripes dependencies to their Sunflower versions. Refs UIPCIR-94.
+* *BREAKING* Migrate `react-intl` to v7. UIPCIR-95.
+
 ## [5.0.1](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v5.0.1) (2024-11-25)
 [Full Changelog](https://github.com/folio-org/ui-plugin-create-inventory-records/compare/v5.0.0...v5.0.1)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/plugin-create-inventory-records",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "Create inventory records for Stripes",
   "repository": "folio-org/ui-plugin-create-inventory-records",
   "publishConfig": {
@@ -115,21 +115,21 @@
     "test:unit": "jest --ci --coverage",
     "test": "yarn run test:unit",
     "build-mod-descriptor": "stripes mod descriptor --full --strict | jq '.[]' > module-descriptor.json ",
-    "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/ui-plugin-create-inventory-records ./translations/ui-plugin-create-inventory-records/compiled"
+    "formatjs-compile": "stripes translate compile"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^7.0.0",
-    "@folio/jest-config-stripes": "^2.0.0",
-    "@folio/stripes": "^9.2.0",
-    "@folio/stripes-cli": "^3.2.0",
-    "@folio/stripes-components": "^12.2.0",
-    "@folio/stripes-core": "^10.2.0",
-    "@folio/stripes-testing": "^4.8.0",
-    "@formatjs/cli": "^6.1.3",
+    "@folio/eslint-config-stripes": "^8.0.0",
+    "@folio/jest-config-stripes": "^3.0.0",
+    "@folio/stripes": "^10.0.0",
+    "@folio/stripes-cli": "^4.0.0",
+    "@folio/stripes-components": "^13.0.0",
+    "@folio/stripes-core": "^11.0.0",
+    "@folio/stripes-testing": "^5.0.0",
+    "@formatjs/cli": "^6.6.0",
     "core-js": "^3.6.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-router-dom": "^5.2.0",
     "regenerator-runtime": "^0.13.3"
   },
@@ -144,10 +144,10 @@
     "react-final-form-listeners": "^1.0.2"
   },
   "peerDependencies": {
-    "@folio/stripes": "^9.2.0",
+    "@folio/stripes": "^10.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-intl": "^6.4.4",
+    "react-intl": "^7.1.5",
     "react-router-dom": "^5.2.0"
   }
 }


### PR DESCRIPTION
## Links
[UIPCIR-94](https://folio-org.atlassian.net/browse/UIPCIR-94)
[UIPCIR-95](https://folio-org.atlassian.net/browse/UIPCIR-95)