### PR TITLE
UIPCIR-101: Make interface dependencies optional (circulation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## (IN PROGRESS)
 * *BREAKING* Creating an item barcode using number generator in Fast Add. Refs UIPCIR-97.
 * Support interface `item-storage` `11.0`. Refs UIPCIR-98.
+* Make interface dependencies optional (circulation). Refs UIPCIR-101.
 
 ## [6.0.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v6.0.0) (2025-03-13)
 [Full Changelog](https://github.com/folio-org/ui-plugin-create-inventory-records/compare/v5.0.1...v6.0.0)

--- a/package.json
+++ b/package.json
@@ -44,8 +44,10 @@
       "holdings-note-types": "1.0",
       "users": "15.0 16.0",
       "location-units": "2.0",
-      "circulation": "9.0 10.0 11.0 12.0 13.0 14.0",
       "settings": "1.1"
+    },
+    "optionalOkapiInterfaces": {
+      "circulation": "9.0 10.0 11.0 12.0 13.0 14.0"
     },
     "permissionSets": [
       {


### PR DESCRIPTION
These interfaces should be optional in the module:

_circulation_