### PR TITLE
UIPCIR-103: Set `statusId` as `null` by default in order not to fail Fast add record creation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,12 @@
 {
   "parser": "babel-eslint",
-  "extends": "@folio/eslint-config-stripes"
+  "extends": "@folio/eslint-config-stripes",
+  "overrides": [
+    {
+      "files": [ "src/**"],
+      "rules": {
+        "react/forbid-prop-types": [ 1, { "forbid": [ "array" ] } ]
+      }
+    }
+  ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,12 +1,4 @@
 {
   "parser": "babel-eslint",
-  "extends": "@folio/eslint-config-stripes",
-  "overrides": [
-    {
-      "files": [ "src/**"],
-      "rules": {
-        "react/forbid-prop-types": [ 1, { "forbid": [ "array" ] } ]
-      }
-    }
-  ]
+  "extends": "@folio/eslint-config-stripes"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-plugin-create-inventory-records
 
+## 7.0.1 (IN PROGRESS)
+
+* Set `statusId` as `null` by default in order not to fail Fast add record creation. Fixes UIPCIR-103.
+
 ## [7.0.0](https://github.com/folio-org/ui-plugin-create-inventory-records/tree/v7.0.0) (2026-04-15)
 [Full Changelog](https://github.com/folio-org/ui-plugin-create-inventory-records/compare/v6.0.0...v7.0.0)
 

--- a/src/providers/DataProvider.js
+++ b/src/providers/DataProvider.js
@@ -36,7 +36,7 @@ const DataProvider = ({
     try {
       const { instanceStatusCode, defaultDiscoverySuppress } = JSON.parse(value);
       const discoverySuppress = JSON.parse(defaultDiscoverySuppress);
-      const statusId = (instanceStatuses.find(status => status.code === instanceStatusCode) || {}).id || '';
+      const statusId = (instanceStatuses.find(status => status.code === instanceStatusCode) || {}).id || null;
 
       config = {
         discoverySuppress,


### PR DESCRIPTION
[UIPCIR-103](https://folio-org.atlassian.net/browse/UIPCIR-103)

* `statusId` as an empty string caused error during fast add record creation. BE thrown a validation error.
* Added eslint rule.